### PR TITLE
AI-0002: Fix `generateText` result type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainulabs/ainu",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "A simple, light weight, and unopinionated ai framework.",
   "license": "ISC",
   "author": "",
@@ -39,7 +39,7 @@
     "test:tools": "jest --testPathPattern=tests/tools",
     "test:providers": "jest --testPathPattern=tests/providers",
     "test:utils": "jest --testPathPattern=tests/util",
-    "test:agents": "jest --testPathPattern=tests/agents",
+    "test:agent": "jest --testPathPattern=tests/agent",
     "test:mcp": "jest --testPathPattern=tests/mcp",
     "mock:mcp": "node --import tsx tests/mcp/mockMcpServer.ts"
   },

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -1,9 +1,9 @@
-import { generateText } from "ai";
+import { generateText, GenerateTextResult, streamText, ToolSet } from "ai";
 import { MCP } from "../mcp/mcp";
 import { Provider } from "../providers";
 import { Tool } from "../tools";
 import { buildTools } from "../tools/util";
-import { AgentError, err, getMessages, ok } from "../utils";
+import { AgentError, err, getMessages, ok, Result } from "../utils";
 import { toMap } from "../utils/transform";
 import {
   AgentOptions,
@@ -78,7 +78,7 @@ export class Agent {
       messages: getMessages({ prompt, messages }),
     };
 
-    let result;
+    let result: Result<GenerateTextResult<ToolSet, unknown> | undefined>;
     try {
       const data = await generateText(config);
 
@@ -117,7 +117,7 @@ export class Agent {
       messages: getMessages({ prompt, messages }),
     };
 
-    return generateText(config);
+    return streamText(config);
   }
 
   /** Adds or replaces a tool in the agent's tools. */

--- a/tests/agent/agent.test.ts
+++ b/tests/agent/agent.test.ts
@@ -30,6 +30,18 @@ describe("Agent", () => {
     expect(agent).toBeDefined();
     expect(agent.name).toBe("testAgent");
   });
+
+  it("should return a result object", async () => {
+    const agent = new Agent({
+      provider,
+    });
+    const result = await agent.generateText({
+      modelId: "test-model",
+      prompt: "Hello, world!",
+    });
+
+    expect(result).toBeDefined();
+  });
 });
 
 describe("Agent settings", () => {


### PR DESCRIPTION
- Correctly type the `generateText` result to fix intellisense
- Fix path for agent tests in `package.json`
- Fix method call for `streamText`
- Add test for `generateText` result type.